### PR TITLE
feat: 회고록 기능 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/diray/api/DiaryController.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/api/DiaryController.java
@@ -1,0 +1,46 @@
+package com.clover.habbittracker.domain.diray.api;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.habbittracker.domain.diray.dto.DiaryRequest;
+import com.clover.habbittracker.domain.diray.dto.DiaryResponse;
+import com.clover.habbittracker.domain.diray.service.DiarySevice;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diaries")
+public class DiaryController {
+
+	private final DiarySevice diarySevice;
+
+	@PostMapping
+	ResponseEntity<Long> createDiary(Authentication authentication,@RequestBody DiaryRequest request) {
+		Long memberId = (Long)authentication.getPrincipal();
+		return new ResponseEntity<>(diarySevice.register(memberId,request), HttpStatus.OK);
+	}
+
+	@GetMapping
+	ResponseEntity<List<DiaryResponse>> getMyDiaryList(Authentication authentication, @RequestParam(required = false) String date) {
+		Long memberId = (Long) authentication.getPrincipal();
+		return new ResponseEntity<>(diarySevice.getMyList(memberId,date),HttpStatus.OK);
+	}
+
+	@PutMapping("/{diaryId}")
+	ResponseEntity<DiaryResponse> updateDiary(@PathVariable Long diaryId, @RequestBody DiaryRequest request) {
+		return new ResponseEntity<>(diarySevice.updateDiary(diaryId, request),HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/dto/DiaryRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/dto/DiaryRequest.java
@@ -1,0 +1,10 @@
+package com.clover.habbittracker.domain.diray.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DiaryRequest {
+
+	private String content;
+
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/dto/DiaryResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/dto/DiaryResponse.java
@@ -1,0 +1,25 @@
+package com.clover.habbittracker.domain.diray.dto;
+
+import java.time.LocalDateTime;
+
+import com.clover.habbittracker.domain.diray.entity.Diary;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DiaryResponse {
+	private Long id;
+	private String content;
+	private LocalDateTime createDate;
+
+	public static DiaryResponse from(Diary diary) {
+		return DiaryResponse.builder()
+			.id(diary.getId())
+			.content(diary.getContent())
+			.createDate(diary.getUpdatedAt())
+			.build();
+	}
+
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/entity/Diary.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/entity/Diary.java
@@ -1,0 +1,42 @@
+package com.clover.habbittracker.domain.diray.entity;
+
+import java.time.LocalDateTime;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.global.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "diary")
+public class Diary extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Setter
+	private String content;
+
+	private LocalDateTime endUpdateDate;
+
+	@ManyToOne
+	@JoinColumn(name = "memberId")
+	private Member member;
+
+
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/repository/DiaryRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/repository/DiaryRepository.java
@@ -1,0 +1,21 @@
+package com.clover.habbittracker.domain.diray.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.clover.habbittracker.domain.diray.entity.Diary;
+
+public interface DiaryRepository extends JpaRepository<Diary,Long> {
+	@Query("""
+			SELECT d
+			FROM Diary d
+			WHERE d.member.id = :memberId
+			AND d.createdAt BETWEEN :start AND :end
+		""")
+	List<Diary> findByMemberId(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/service/DiaryServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/service/DiaryServiceImpl.java
@@ -1,0 +1,65 @@
+package com.clover.habbittracker.domain.diray.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.clover.habbittracker.domain.diray.dto.DiaryRequest;
+import com.clover.habbittracker.domain.diray.dto.DiaryResponse;
+import com.clover.habbittracker.domain.diray.entity.Diary;
+import com.clover.habbittracker.domain.diray.repository.DiaryRepository;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.util.DateCalculate;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryServiceImpl implements DiarySevice {
+
+	private final DiaryRepository diaryRepository;
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public Long register(Long memberId, DiaryRequest request) {
+		Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
+
+		Diary diary = Diary.builder()
+			.content(request.getContent())
+			.member(member)
+			.endUpdateDate(LocalDateTime.now().plusHours(24))
+			.build();
+		diaryRepository.save(diary);
+
+		return diary.getId();
+	}
+
+	@Override
+	public List<DiaryResponse> getMyList(Long memberId, String date) {
+		Map<String, LocalDateTime> dateMap = DateCalculate.startEnd(date);
+
+		return diaryRepository.findByMemberId(memberId, dateMap.get("start"), dateMap.get("end"))
+			.stream()
+			.map(DiaryResponse::from)
+			.toList();
+	}
+
+
+	@Override
+	@Transactional
+	public DiaryResponse updateDiary(Long diaryId, DiaryRequest request) {
+		Diary diary = diaryRepository.findById(diaryId).orElseThrow();
+		if (diary.getEndUpdateDate().isBefore(LocalDateTime.now())) {
+			throw new RuntimeException("마감 날짜 지남");
+		}
+		Optional.ofNullable(request.getContent()).ifPresent(diary::setContent);
+
+		return DiaryResponse.from(diary);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/diray/service/DiarySevice.java
+++ b/src/main/java/com/clover/habbittracker/domain/diray/service/DiarySevice.java
@@ -1,0 +1,14 @@
+package com.clover.habbittracker.domain.diray.service;
+
+import java.util.List;
+
+import com.clover.habbittracker.domain.diray.dto.DiaryRequest;
+import com.clover.habbittracker.domain.diray.dto.DiaryResponse;
+
+public interface DiarySevice {
+	Long register(Long memberId, DiaryRequest request);
+
+	List<DiaryResponse> getMyList(Long memberId, String date);
+
+	DiaryResponse updateDiary(Long diaryId, DiaryRequest request);
+}

--- a/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
@@ -2,7 +2,6 @@ package com.clover.habbittracker.domain.habit.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +17,7 @@ import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
 import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.util.DateCalculate;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,7 +43,7 @@ public class HabitServiceImpl implements HabitService {
 
 	@Override
 	public List<MyHabitResponse> getMyList(Long memberId,String date) {
-		Map<String, LocalDateTime> dateMap = DateCalc.startEnd(date);
+		Map<String, LocalDateTime> dateMap = DateCalculate.startEnd(date);
 		return
 			habitRepository.joinHabitCheckFindByMemberId(memberId,dateMap.get("start"),dateMap.get("end"))
 				.stream().map(MyHabitResponse::from)
@@ -79,20 +79,5 @@ public class HabitServiceImpl implements HabitService {
 		LocalDateTime now = LocalDateTime.now();
 		Duration duration = Duration.between(updateDate,now);
 		return duration.toDays() == 0;
-	}
-
-	private static class DateCalc {
-		private static final String FORMAT = "-01T00:00:00.000000";
-
-		private static Map<String,LocalDateTime> startEnd(String date) {
-			Map<String, LocalDateTime> result = new HashMap<>();
-			if (date == null) {
-				date = LocalDateTime.now().toString().substring(0,7);
-			}
-			LocalDateTime parse = LocalDateTime.parse(date + FORMAT);
-			result.put("start", parse.withDayOfMonth(1));
-			result.put("end", parse.plusMonths(1));
-			return result;
-		}
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/util/DateCalculate.java
+++ b/src/main/java/com/clover/habbittracker/global/util/DateCalculate.java
@@ -1,0 +1,21 @@
+package com.clover.habbittracker.global.util;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DateCalculate {
+	public static final String FORMAT = "-01T00:00:00.000000";
+
+	public static Map<String, LocalDateTime> startEnd(String date) {
+		Map<String, LocalDateTime> result = new HashMap<>();
+		if (date == null) {
+			date = LocalDateTime.now().toString().substring(0, 7);
+		}
+		LocalDateTime parse = LocalDateTime.parse(date + FORMAT);
+		result.put("start", parse.withDayOfMonth(1));
+		result.put("end", parse.plusMonths(1));
+		return result;
+	}
+
+}

--- a/src/main/resources/application-token.yml
+++ b/src/main/resources/application-token.yml
@@ -3,5 +3,6 @@ spring:
     import: optional:file:.env[.properties]
 jwt:
   secret: ${JWT_SECRET}
-  expiredMs: 3600000
+#  expiredMs: 3600000
+  expiredMs: 604800000
   refreshExpiredMs: 604800000


### PR DESCRIPTION
### 작업 사항
- 회고록 등록, 수정, 조회 서비스를 구현했습니다.
- 회고록은 등록 날짜 기준으로 24시간내에 수정이 가능하며 그 이후의 시간은 변경이 불가능합니다.
- 회고록 조회는 현재 날짜 기준으로 그 해당 달만 조회 합니다.
- 쿼리 스트링으로 연월의 정보를 같이 주면 그 해당년도 해당 월의 대한 조회가 가능합니다.
- 회고록 조회는 습관 조회와 마찬가지로 현재 로그인한 회원에 대한 회고록 리스트를 조회합니다