### PR TITLE
fix: 소셜 로그인 redirect_uri 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/security/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import com.clover.habbittracker.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.clover.habbittracker.global.security.jwt.JwtFilter;
+import com.clover.habbittracker.global.security.oauth.HttpCookieOAuthAuthorizationRequestRepository;
+import com.clover.habbittracker.global.security.oauth.OAuthFailureHandler;
 import com.clover.habbittracker.global.security.oauth.OauthSuccessHandler;
 
 
@@ -26,6 +28,10 @@ public class SecurityConfig {
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 	private final OauthSuccessHandler oauthSuccessHandler;
+
+	private final HttpCookieOAuthAuthorizationRequestRepository httpCookieOAuthAuthorizationRequestRepository;
+
+	private final OAuthFailureHandler oAuthFailureHandler;
 
 	@Bean
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -47,7 +53,12 @@ public class SecurityConfig {
 			.anyRequest().permitAll()
 			.and()
 			.oauth2Login()
+			.authorizationEndpoint()
+			.baseUri("/oauth2/authorization")
+			.authorizationRequestRepository(httpCookieOAuthAuthorizationRequestRepository)
+			.and()
 			.successHandler(oauthSuccessHandler)
+			.failureHandler(oAuthFailureHandler)
 			.and()
 			.addFilterBefore(jwtFilter, OAuth2AuthorizationRequestRedirectFilter.class)
 			.exceptionHandling()

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/OAuthFailureHandler.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/OAuthFailureHandler.java
@@ -1,0 +1,45 @@
+package com.clover.habbittracker.global.security.oauth;
+
+
+import static com.clover.habbittracker.global.security.oauth.HttpCookieOAuthAuthorizationRequestRepository.*;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.clover.habbittracker.global.util.CookieUtil;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthFailureHandler
+	extends SimpleUrlAuthenticationFailureHandler {
+
+	private static final String DEFAULT_TARGET_URL = "/";
+	private final HttpCookieOAuthAuthorizationRequestRepository httpCookieOAuthAuthorizationRequestRepository;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		String redirectUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+			.map(Cookie::getValue)
+			.orElse(DEFAULT_TARGET_URL);
+
+		String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
+			.queryParam("error", exception.getMessage())
+			.build().toUriString();
+
+		httpCookieOAuthAuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+}
+
+

--- a/src/main/java/com/clover/habbittracker/global/security/oauth/OauthSuccessHandler.java
+++ b/src/main/java/com/clover/habbittracker/global/security/oauth/OauthSuccessHandler.java
@@ -4,8 +4,6 @@ import static com.clover.habbittracker.global.security.oauth.HttpCookieOAuthAuth
 
 import java.io.IOException;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -14,7 +12,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.clover.habbittracker.global.security.oauth.dto.SocialUser;
 import com.clover.habbittracker.global.util.CookieUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -27,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class OauthSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 	private final OauthService oauthService;
 
+	// private final CustomRedirectStrategy customRedirectStrategy;
 	// private final ObjectMapper objectMapper;
 
 	@Override
@@ -39,7 +37,8 @@ public class OauthSuccessHandler extends SavedRequestAwareAuthenticationSuccessH
 		if (principal instanceof OAuth2User user) {
 			SocialUser userInfo = OauthProvider.getProfile(user, provider);
 			String accessToken = oauthService.login(userInfo);
-			String targetUrl = determineTargetUrl(request, accessToken);
+			String targetUrl = determineTargetUrl(request,accessToken);
+			// setRedirectStrategy(customRedirectStrategy);
 			getRedirectStrategy().sendRedirect(request, response, targetUrl);
 			// response.setStatus(HttpStatus.OK.value());
 			// response.setContentType("application/json");
@@ -51,12 +50,12 @@ public class OauthSuccessHandler extends SavedRequestAwareAuthenticationSuccessH
 
 	}
 
-	private String determineTargetUrl(HttpServletRequest request, String accessToken) {
+	private String determineTargetUrl(HttpServletRequest request,String accessToken) {
 		String targetUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
 			.map(Cookie::getValue)
 			.orElse(getDefaultTargetUrl());
 
-		return UriComponentsBuilder.fromUriString("https://clover-beta.vercel.app/myhabit")
+		return UriComponentsBuilder.fromUriString(targetUrl)
 			.queryParam("accessToken", accessToken) // url에도 실어 보내기
 			.build().toUriString();
 	}

--- a/src/main/java/com/clover/habbittracker/global/util/CookieUtil.java
+++ b/src/main/java/com/clover/habbittracker/global/util/CookieUtil.java
@@ -34,7 +34,7 @@ public class CookieUtil {
 		Cookie cookie = new Cookie(name, value);
 		cookie.setPath("/");
 		cookie.setHttpOnly(true);
-		cookie.setSecure(true);
+		cookie.setSecure(false);
 		cookie.setMaxAge(maxAge);
 		response.addCookie(cookie);
 	}


### PR DESCRIPTION
### 작업 사항
- 현재 클라이언트가 요청하는 redirect_uri를 받아오지 못하고 디폴트 리다이렉트로 반환하여, 임시로 클라이언트 도메인을 직접 사용했었습니다.
- SecuritConfig 에서 HttpCookieOAuthAuthorizationRequestRepository 설정이 누락되어 있어 추가했습니다.
- 로그인 실패 했을 때 에러 메세지를 담아 보내는 Handler도 추가했습니다.
- CookieUtil에서 https를 사용하지 않음에도 secure 설정이 되어 있는 부분 수정하였습니다.

이제 url에서 직접 redirect_uri 추가하여 보내면 정상적으로 해당 uri로 직접 토큰 값 쿼리 파라미터에 담아 보냅니다.