### PR TITLE
Fix: Jwt 및 CD-Depoly 오류 수정

### DIFF
--- a/.github/workflows/CD-Deploy.yml
+++ b/.github/workflows/CD-Deploy.yml
@@ -73,5 +73,6 @@ jobs:
           script: |
             sudo docker rm -f $(docker ps -qa)
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/habiters:latest
+            cd /home/clover
             docker-compose up -d
             docker image prune -f

--- a/src/test/java/com/clover/habbittracker/global/security/jwt/JwtFilterTest.java
+++ b/src/test/java/com/clover/habbittracker/global/security/jwt/JwtFilterTest.java
@@ -65,4 +65,14 @@ public class JwtFilterTest {
 		assertThrows(JwtException.class,
 			() -> jwtFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain));
 	}
+
+	@Test
+	@DisplayName("인증이 필요하지 않다면, 필터에 걸리지않게 한다.")
+	void noAuthorizationFiler() {
+		//when
+		boolean shouldNotFilter = jwtFilter.shouldNotFilter(httpServletRequest);
+		//then
+		assertThat(shouldNotFilter).isTrue();
+
+	}
 }


### PR DESCRIPTION
### 작업 사항
- Authorization 헤더가 없는 경우에 예외가 터지는 것을 수정했습니다.
- Authorization 헤더가 없을 경우에는 shouldNotFilter 를 활용하여 필터스프링 필터 체인으로 넘어가게 수정했습니다.
- 해당 메소드 사용으로 전체적인 코드를 수정하였습니다.
- 서버가배포되고 바로 실행이 안되는 이유가 디렉토리 문제여서 수정했습니다.