### PR TITLE
Feat : Diary Test Code 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,31 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
-    finalizedBy jacocoTestReport
+    finalizedBy 'jacocoTestReport'
 }
 
 jacocoTestReport {
     dependsOn test
+    finalizedBy 'jacocoTestCoverageVerification'
     reports {
         html.enabled true
         xml.enabled true
     }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            excludes = [
+                    '*.global.security.oauth*',
+                    '*.global.util*',
+                    '*.global.dto*',
+                    '*.global.exception*'
+            ]
+
+        }
+
+    }
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryRequest.java
@@ -1,10 +1,19 @@
 package com.clover.habbittracker.domain.diary.dto;
 
-import lombok.Getter;
+import java.util.Optional;
 
-@Getter
+import com.clover.habbittracker.domain.diary.exception.DiaryException;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
 public class DiaryRequest {
 
 	private String content;
 
+	public String getContent() {
+		return Optional.ofNullable(content).orElseThrow(() -> new DiaryException("회고 내용이 없습니다."));
+	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/diary/service/DiaryServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/service/DiaryServiceImpl.java
@@ -3,6 +3,7 @@ package com.clover.habbittracker.domain.diary.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class DiaryServiceImpl implements DiaryService {
 
 	@Override
 	public Long register(Long memberId, DiaryRequest request) {
-		Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
+		Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchElementException("회원 정보가 존재하지 않습니다."));
 
 		Diary diary = Diary.builder()
 			.content(request.getContent())
@@ -44,7 +45,6 @@ public class DiaryServiceImpl implements DiaryService {
 	@Override
 	public List<DiaryResponse> getMyList(Long memberId, String date) {
 		Map<String, LocalDateTime> dateMap = DateCalculate.startEnd(date);
-
 		return diaryRepository.findByMemberId(memberId, dateMap.get("start"), dateMap.get("end"))
 			.stream()
 			.map(DiaryResponse::from)
@@ -55,7 +55,7 @@ public class DiaryServiceImpl implements DiaryService {
 	@Override
 	@Transactional
 	public DiaryResponse updateDiary(Long diaryId, DiaryRequest request) {
-		Diary diary = diaryRepository.findById(diaryId).orElseThrow();
+		Diary diary = diaryRepository.findById(diaryId).orElseThrow(() -> new NoSuchElementException("회고록 정보가 존재하지 않습니다."));
 		if (diary.getEndUpdateDate().isBefore(LocalDateTime.now())) {
 			throw new DiaryException("마감 날짜 지남");
 		}

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -1,0 +1,117 @@
+package com.clover.habbittracker.domain.diary.api;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static org.hamcrest.core.Is.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.clover.habbittracker.domain.diary.dto.DiaryRequest;
+import com.clover.habbittracker.domain.diary.entity.Diary;
+import com.clover.habbittracker.domain.diary.repository.DiaryRepository;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.security.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class DiaryControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private DiaryRepository diaryRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	private String accessJwt;
+
+	private Diary saveDiary;
+
+	@BeforeEach
+	void setUp() {
+		Member testMember = memberRepository.save(createTestMember());
+		accessJwt = jwtProvider.createAccessJwt(testMember.getId());
+		Diary diary = Diary.builder()
+			.endUpdateDate(LocalDateTime.now().plusHours(24))
+			.member(testMember)
+			.content("미리 저장된 테스트 회고록입니다.")
+			.build();
+		saveDiary = diaryRepository.save(diary);
+
+
+	}
+
+	@Test
+	@DisplayName("사용자는 회고록을 등록 할 수 있다.")
+	void createDiaryTest() throws Exception {
+		//given
+		DiaryRequest diaryRequest = new DiaryRequest("테스트 회고록입니다.");
+		String request = new ObjectMapper().writeValueAsString(diaryRequest);
+
+		//when then
+		mockMvc.perform(
+			post("/diaries")
+				.header("Authorization","Bearer " + accessJwt)
+				.contentType(APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("사용자는 회고록을 수정 할 수 있다.")
+	void updateDiaryTest() throws Exception {
+		//given
+		DiaryRequest diaryRequest = new DiaryRequest("회고록 수정내용 입니다.");
+		String request = new ObjectMapper().writeValueAsString(diaryRequest);
+
+		//when then
+		mockMvc.perform(
+				put("/diaries/"+ saveDiary.getId())
+					.header("Authorization","Bearer " + accessJwt)
+					.contentType(APPLICATION_JSON)
+					.content(request))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id", is(saveDiary.getId().intValue())))
+			.andExpect(jsonPath("$.content", is(diaryRequest.getContent())))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("사용자는 회고록을 전체 조회 할 수 있다.")
+	void getMyDiaryListTest() throws Exception {
+		//when then
+		mockMvc.perform(
+				get("/diaries")
+					.header("Authorization", "Bearer " + accessJwt))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("사용자는 나의 회고록을 삭제 할 수 있다.")
+	void deleteDiaryTest() throws Exception {
+		//when then
+		mockMvc.perform(
+				delete("/diaries/" + saveDiary.getId())
+					.header("Authorization", "Bearer " + accessJwt))
+			.andExpect(status().isNoContent())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -1,0 +1,109 @@
+package com.clover.habbittracker.domain.diary.repository;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.clover.habbittracker.domain.diary.entity.Diary;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.util.DateCalculate;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+public class DiaryRepositoryTest {
+
+	@Autowired
+	private DiaryRepository diaryRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member testMember;
+
+	@BeforeEach
+	void setUp() {
+		testMember = memberRepository.save(createTestMember());
+	}
+
+	@Test
+	@DisplayName("회고록을 저장 할 수 있다.")
+	void saveTest() {
+		//given
+		Diary testDiary = Diary.builder().content("회고록 테스트입니다.").build();
+
+		//when
+		Diary saveDiary = diaryRepository.save(testDiary);
+
+		//then
+		assertThat(saveDiary).isEqualTo(testDiary);
+		assertThat(saveDiary).usingRecursiveComparison().isEqualTo(testDiary);
+	}
+
+	@Test
+	@DisplayName("회고록 ID로 회고내용을 조회 할 수 있다.")
+	void findByIdTest() {
+		//given
+		Diary testDiary = Diary.builder().content("회고록 테스트입니다.").build();
+		diaryRepository.save(testDiary);
+
+		//when
+		Optional<Diary> optionalDiary = diaryRepository.findById(testDiary.getId());
+
+		//then
+		assertThat(optionalDiary).isPresent();
+		assertThat(optionalDiary.get()).isEqualTo(testDiary);
+	}
+
+	@Test
+	@DisplayName("회고록 ID로 회고 내용을 삭제 할 수 있다.")
+	void deleteByIdTest() {
+		//given
+		Diary testDiary = Diary.builder().content("회고록 테스트입니다.").build();
+		diaryRepository.save(testDiary);
+
+		//when
+		diaryRepository.deleteById(testDiary.getId());
+
+		//then
+		Optional<Diary> optionalDiary = diaryRepository.findById(testDiary.getId());
+		assertThat(optionalDiary).isEmpty();
+	}
+
+	@Test
+	@DisplayName("사용자의 월별 회고록 리스트를 조회 할 수 있다.")
+	void findByMemberIdDateBetweenTest() {
+		//given
+		for (int i = 0; i < 10; i++) {
+			diaryRepository.save(Diary.builder().content("테스트회고입니다." + i).member(testMember).build());
+		}
+		Map<String, LocalDateTime> dateTimeMap1 = DateCalculate.startEnd("2023-04");
+		Map<String, LocalDateTime> dateTimeMap2 = DateCalculate.startEnd("2023-03");
+
+		//when
+		List<Diary> diaryList1 = diaryRepository.findByMemberId(testMember.getId(), dateTimeMap1.get("start"),
+			dateTimeMap1.get("end"));
+		List<Diary> diaryList2 = diaryRepository.findByMemberId(testMember.getId(), dateTimeMap2.get("start"),
+			dateTimeMap2.get("end"));
+
+		//then
+		assertThat(diaryList1.size()).isEqualTo(10);
+		assertThat(diaryList2.size()).isEqualTo(0);
+		diaryList1.forEach(
+			diary -> assertThat(diary)
+				.hasFieldOrProperty("id")
+				.hasFieldOrProperty("content"));
+	}
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
@@ -1,0 +1,140 @@
+package com.clover.habbittracker.domain.diary.service;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.clover.habbittracker.domain.diary.dto.DiaryRequest;
+import com.clover.habbittracker.domain.diary.dto.DiaryResponse;
+import com.clover.habbittracker.domain.diary.entity.Diary;
+import com.clover.habbittracker.domain.diary.exception.DiaryException;
+import com.clover.habbittracker.domain.diary.repository.DiaryRepository;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+
+@SpringBootTest
+public class DiaryServiceTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private DiaryService diaryService;
+	@Autowired
+	private DiaryRepository diaryRepository;
+
+	private Member testMember;
+
+	@BeforeEach
+	void setUp() {
+		testMember = memberRepository.save(createTestMember());
+	}
+
+	@Test
+	@DisplayName("사용자 ID와 회고내용을 받아 회고록을 등록 할 수 있다.")
+	@Transactional
+	void registerTest() {
+		//given
+		DiaryRequest diaryRequest = new DiaryRequest("테스트 회고록입니다.");
+
+		//when
+		Long diaryId = diaryService.register(testMember.getId(), diaryRequest);
+
+		// then
+		Optional<Diary> savedDiary = diaryRepository.findById(diaryId);
+		assertThat(savedDiary).isPresent();
+		assertThat(savedDiary.get().getMember()).isEqualTo(testMember);
+	}
+
+	@Test
+	@DisplayName("사용자 Id와 수정 할 회고 내용을 받아 회고록을 수정 할 수 있다.")
+	void updateDiaryTest() {
+		//given
+		DiaryRequest diaryRequest = new DiaryRequest("테스트 회고록입니다.");
+		Long diaryId = diaryService.register(testMember.getId(), diaryRequest);
+		DiaryRequest updateRequest = new DiaryRequest("회고록 수정내용입니다.");
+
+		//when
+		DiaryResponse diaryResponse = diaryService.updateDiary(diaryId, updateRequest);
+
+		//then
+		assertThat(diaryResponse)
+			.hasFieldOrPropertyWithValue("id", diaryId)
+			.hasFieldOrPropertyWithValue("content", updateRequest.getContent());
+	}
+
+	@Test
+	@DisplayName("회고록은 최초 작성 후 24시간이 지나면 수정할 수 없다.")
+	void endUpdateDateTest() {
+		//given
+		Diary diary = Diary.builder()
+			.content("테스트 회고록입니다.")
+			.member(testMember)
+			.endUpdateDate(LocalDateTime.now().minusDays(1))
+			.build();
+		Diary saveDiary = diaryRepository.save(diary);
+		DiaryRequest updateRequest = new DiaryRequest("회고록 수정내용입니다.");
+		//when 	then
+		assertThrows(DiaryException.class,() -> diaryService.updateDiary(saveDiary.getId(), updateRequest));
+
+	}
+
+	@Test
+	@DisplayName("사용자 Id를 받아 나의 월별 회고록 리스트를 조회 할 수 있다.")
+	@Transactional
+	void getMyDiaryList() {
+		//given
+		for (int i = 0; i < 10; i++) {
+			diaryService.register(testMember.getId(),new DiaryRequest("테스트 회고록입니다." + i));
+		}
+
+		//when
+		List<DiaryResponse> myList1 = diaryService.getMyList(testMember.getId(), "2023-04");
+		List<DiaryResponse> myList2 = diaryService.getMyList(testMember.getId(), "2023-02");
+
+		//then
+		myList1.forEach(
+			diaryResponse -> assertThat(diaryResponse)
+				.hasFieldOrProperty("id")
+				.hasFieldOrProperty("content"));
+
+		assertThat(myList2.size()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("회고 내용이 없다면 등록 시 예외가 터진다.")
+	void failedRegisterDiaryTest() {
+		//given
+		Long testMemberId = testMember.getId();
+		DiaryRequest diaryRequest = new DiaryRequest(null);
+
+		//when then
+		assertThrows(DiaryException.class, () -> diaryService.register(testMemberId, diaryRequest));
+	}
+
+	@Test
+	@DisplayName("잘못된 회고록 ID, 사용자 ID 를 요청하면 예외가 터진다.")
+	void wrongHabitIdTest() {
+		//given
+		Long wrongDiaryId = 0L;
+		DiaryRequest diaryRequest = new DiaryRequest("테스트 회고록입니다.");
+
+		//when then
+		assertAll(
+			() -> assertThrows(NoSuchElementException.class, () -> diaryService.register(wrongDiaryId,diaryRequest)),
+			() -> assertThrows(NoSuchElementException.class, () -> diaryService.updateDiary(wrongDiaryId,diaryRequest))
+		);
+	}
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.clover.habbittracker.domain.habitCheck.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.clover.habbittracker.domain.habit.entity.Habit;
+import com.clover.habbittracker.domain.habit.repository.HabitRepository;
+import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
+import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
+import com.clover.habbittracker.global.config.JpaConfig;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+public class HabitCheckRepositoryTest {
+
+	@Autowired
+	private HabitCheckRepository habitCheckRepository;
+
+	@Autowired
+	private HabitRepository habitRepository;
+
+	@Test
+	@DisplayName("습관 체크를 저장할 수 있다.")
+	void saveHabitCheckTest() {
+
+		//given
+		Habit testHabit = Habit.builder().content("테스트 습관입니다.").build();
+		HabitCheck testHabitCheck = HabitCheck.builder().checked(true).habit(testHabit).build();
+
+		//when
+		HabitCheck habitCheck = habitCheckRepository.save(testHabitCheck);
+
+		//then
+		assertThat(habitCheck.getHabit()).isEqualTo(testHabit);
+	}
+
+
+	@Test
+	@DisplayName("습관정보로 습관 체크 내역을 조회 할 수 있다.")
+	void findByHabitTest() {
+		//given
+		Habit testHabit = Habit.builder().content("테스트 습관입니다.").build();
+		habitRepository.save(testHabit);
+		habitCheckRepository.save(HabitCheck.builder().checked(true).habit(testHabit).build());
+
+		//when
+		Optional<HabitCheck> optionalHabitCheck = habitCheckRepository.findByHabit(testHabit);
+
+		//then
+		assertThat(optionalHabitCheck).isPresent();
+		assertThat(optionalHabitCheck.get().getHabit()).isEqualTo(testHabit);
+	}
+
+	@Test
+	@DisplayName("습관 정보로 가장 최근에 체크된 내역을 조회 할 수 있다.")
+	void findByHabitOrderByDescTest() {
+		//given
+		Habit testHabit = Habit.builder().content("테스트 습관입니다.").build();
+		habitRepository.save(testHabit);
+		for (int i = 0; i < 10; i++) {
+			habitCheckRepository.save(HabitCheck.builder().checked(true).habit(testHabit).build());
+		}
+
+		//when
+		Optional<HabitCheck> byHabitOrderByIdDesc = habitCheckRepository.findByHabitOrderByUpdatedAtDesc(testHabit);
+
+		//then
+		assertThat(byHabitOrderByIdDesc).isPresent();
+		assertThat(byHabitOrderByIdDesc.get().getId()).isGreaterThan(1L);
+	}
+
+}


### PR DESCRIPTION
### 작업 사항

### Diary 추가 사항

[feat(Test_Diary) : DiaryController 테스트 코드 작성.](https://github.com/potenday-project/Clover/commit/979e2300d75709c0763d651562490bd4b561e77f)

[feat(Test_Diary) : DiaryRepository 테스트 코드 작성.](https://github.com/potenday-project/Clover/commit/d19c584b15ed14e686c97a91d142bc41dab3a7bd)

[feat(Test_Diary) : DiaryService 테스트 코드 작성.](https://github.com/potenday-project/Clover/commit/e3ed8b0cafc9af5784392217b8191c1dcdade3c0)
- 기존 Diary 서비스에 대한 코드 검증과 메소드들의 역활을 정확하게 하기위해 테스트 코드를 추가하였습니다.


[feat(Diary) : content 유효성 검증 추가](https://github.com/potenday-project/Clover/commit/8084a7e9bc085cb525fe9f4aaad761fb33036ef4)
- diary를 생성 후 content를 가져 올 때 Optional 을 사용하여 null인 경우 예외를 발생하도록 했습니다.

---
### Diary 수정 사항

[fix(Diary) : DiaryServiceImpl 예외 수정](https://github.com/potenday-project/Clover/commit/17bdb221c748340cc8af678243c594ea2954c7ce)
- 회고록 존재 하지 않을경우 IllegalArgumentException 예외 보단 NoSuchElementException 예외가 더 적합한거같아 수정했습니다.

---

### etc

### config
[config : jacoco 설정 추가](https://github.com/potenday-project/Clover/commit/17b666fd5c1474b2371c8612e27d8ae562f1277b)
- 테스트 커버리지 확인 시 특정 패키지는 포함시키지 않게 설정하였습니다.

