### PR TITLE
Feat : BaseResponse dto 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
@@ -34,26 +34,30 @@ public class DiaryController {
 	@PostMapping
 	ResponseEntity<BaseResponse<Long>> createDiary(@AuthenticationPrincipal Long memberId, @RequestBody DiaryRequest request) {
 		Long registerId = diaryService.register(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(registerId, DIARY_CREATE), HttpStatus.CREATED);
+		BaseResponse<Long> response = BaseResponse.of(registerId, DIARY_CREATE);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
 	@GetMapping
 	ResponseEntity<BaseResponse<List<DiaryResponse>>> getMyDiaryList(@AuthenticationPrincipal Long memberId,
 		@RequestParam(required = false) String date) {
 		List<DiaryResponse> myDiaryList = diaryService.getMyList(memberId, date);
-		return new ResponseEntity<>(BaseResponse.of(myDiaryList, DIARY_READ), HttpStatus.OK);
+		BaseResponse<List<DiaryResponse>> response = BaseResponse.of(myDiaryList, DIARY_READ);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@PutMapping("/{diaryId}")
 	ResponseEntity<BaseResponse<DiaryResponse>> updateDiary(@PathVariable Long diaryId,
 		@RequestBody DiaryRequest request) {
 		DiaryResponse updateDiary = diaryService.updateDiary(diaryId, request);
-		return new ResponseEntity<>(BaseResponse.of(updateDiary, DIARY_UPDATE), HttpStatus.OK);
+		BaseResponse<DiaryResponse> response = BaseResponse.of(updateDiary, DIARY_UPDATE);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@DeleteMapping("/{diaryId}")
 	ResponseEntity<BaseResponse<Void>> deleteDiary(@PathVariable Long diaryId) {
 		diaryService.delete(diaryId);
-		return new ResponseEntity<>(BaseResponse.of(null, DIARY_DELETE), HttpStatus.NO_CONTENT);
+		BaseResponse<Void> response = BaseResponse.of(null, HABIT_DELETE);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,25 +32,23 @@ public class DiaryController {
 	private final DiaryService diaryService;
 
 	@PostMapping
-	ResponseEntity<BaseResponse<Long>> createDiary(Authentication authentication, @RequestBody DiaryRequest request) {
-		Long memberId = (Long)authentication.getPrincipal();
-		Long data = diaryService.register(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(data, DIARY_CREATE), HttpStatus.CREATED);
+	ResponseEntity<BaseResponse<Long>> createDiary(@AuthenticationPrincipal Long memberId, @RequestBody DiaryRequest request) {
+		Long registerId = diaryService.register(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(registerId, DIARY_CREATE), HttpStatus.CREATED);
 	}
 
 	@GetMapping
-	ResponseEntity<BaseResponse<List<DiaryResponse>>> getMyDiaryList(Authentication authentication,
+	ResponseEntity<BaseResponse<List<DiaryResponse>>> getMyDiaryList(@AuthenticationPrincipal Long memberId,
 		@RequestParam(required = false) String date) {
-		Long memberId = (Long)authentication.getPrincipal();
-		List<DiaryResponse> data = diaryService.getMyList(memberId, date);
-		return new ResponseEntity<>(BaseResponse.of(data, DIARY_READ), HttpStatus.OK);
+		List<DiaryResponse> myDiaryList = diaryService.getMyList(memberId, date);
+		return new ResponseEntity<>(BaseResponse.of(myDiaryList, DIARY_READ), HttpStatus.OK);
 	}
 
 	@PutMapping("/{diaryId}")
 	ResponseEntity<BaseResponse<DiaryResponse>> updateDiary(@PathVariable Long diaryId,
 		@RequestBody DiaryRequest request) {
-		DiaryResponse data = diaryService.updateDiary(diaryId, request);
-		return new ResponseEntity<>(BaseResponse.of(data, DIARY_UPDATE), HttpStatus.OK);
+		DiaryResponse updateDiary = diaryService.updateDiary(diaryId, request);
+		return new ResponseEntity<>(BaseResponse.of(updateDiary, DIARY_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{diaryId}")

--- a/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/api/DiaryController.java
@@ -1,5 +1,7 @@
 package com.clover.habbittracker.domain.diary.api;
 
+import static com.clover.habbittracker.global.dto.ResponseType.*;
+
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.clover.habbittracker.domain.diary.dto.DiaryRequest;
 import com.clover.habbittracker.domain.diary.dto.DiaryResponse;
 import com.clover.habbittracker.domain.diary.service.DiaryService;
+import com.clover.habbittracker.global.dto.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,25 +32,30 @@ public class DiaryController {
 	private final DiaryService diaryService;
 
 	@PostMapping
-	ResponseEntity<Long> createDiary(Authentication authentication,@RequestBody DiaryRequest request) {
+	ResponseEntity<BaseResponse<Long>> createDiary(Authentication authentication, @RequestBody DiaryRequest request) {
 		Long memberId = (Long)authentication.getPrincipal();
-		return new ResponseEntity<>(diaryService.register(memberId,request), HttpStatus.OK);
+		Long data = diaryService.register(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(data, DIARY_CREATE), HttpStatus.CREATED);
 	}
 
 	@GetMapping
-	ResponseEntity<List<DiaryResponse>> getMyDiaryList(Authentication authentication, @RequestParam(required = false) String date) {
-		Long memberId = (Long) authentication.getPrincipal();
-		return new ResponseEntity<>(diaryService.getMyList(memberId,date),HttpStatus.OK);
+	ResponseEntity<BaseResponse<List<DiaryResponse>>> getMyDiaryList(Authentication authentication,
+		@RequestParam(required = false) String date) {
+		Long memberId = (Long)authentication.getPrincipal();
+		List<DiaryResponse> data = diaryService.getMyList(memberId, date);
+		return new ResponseEntity<>(BaseResponse.of(data, DIARY_READ), HttpStatus.OK);
 	}
 
 	@PutMapping("/{diaryId}")
-	ResponseEntity<DiaryResponse> updateDiary(@PathVariable Long diaryId, @RequestBody DiaryRequest request) {
-		return new ResponseEntity<>(diaryService.updateDiary(diaryId, request),HttpStatus.OK);
+	ResponseEntity<BaseResponse<DiaryResponse>> updateDiary(@PathVariable Long diaryId,
+		@RequestBody DiaryRequest request) {
+		DiaryResponse data = diaryService.updateDiary(diaryId, request);
+		return new ResponseEntity<>(BaseResponse.of(data, DIARY_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/{diaryId}")
-	ResponseEntity<Void> deleteDiary(@PathVariable Long diaryId) {
+	ResponseEntity<BaseResponse<Void>> deleteDiary(@PathVariable Long diaryId) {
 		diaryService.delete(diaryId);
-		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		return new ResponseEntity<>(BaseResponse.of(null, DIARY_DELETE), HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
@@ -33,43 +33,51 @@ public class HabitController {
 	private final HabitService habitService;
 
 	@GetMapping
-	ResponseEntity<BaseResponse<List<MyHabitResponse>>> getMyHabitList(@AuthenticationPrincipal Long memberId,
-		@RequestParam(required = false) String date) {
+	public ResponseEntity<BaseResponse<List<MyHabitResponse>>> getMyHabitList(
+			@AuthenticationPrincipal Long memberId,
+			@RequestParam(required = false) String date) {
 		List<MyHabitResponse> myHabitList = habitService.getMyList(memberId, date);
-		return new ResponseEntity<>(BaseResponse.of(myHabitList, HABIT_READ), HttpStatus.OK);
+		BaseResponse<List<MyHabitResponse>> response = BaseResponse.of(myHabitList, HABIT_READ);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@PostMapping
-	ResponseEntity<BaseResponse<Long>> createHabit(
-		@AuthenticationPrincipal Long memberId,
-		@RequestBody HabitRequest request) {
-
+	public ResponseEntity<BaseResponse<Long>> createHabit(
+			@AuthenticationPrincipal Long memberId,
+			@RequestBody HabitRequest request) {
 		Long registerId = habitService.register(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(registerId, HABIT_CREATE), HttpStatus.CREATED);
+		BaseResponse<Long> response = BaseResponse.of(registerId, HABIT_CREATE);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
 	@PutMapping("{habitId}")
-	ResponseEntity<BaseResponse<HabitResponse>> updateHabit(@PathVariable Long habitId,
-		@RequestBody HabitRequest request) {
+	public ResponseEntity<BaseResponse<HabitResponse>> updateHabit(
+			@PathVariable Long habitId,
+			@RequestBody HabitRequest request) {
 		HabitResponse updateHabit = habitService.updateMyHabit(habitId, request);
-		return new ResponseEntity<>(BaseResponse.of(updateHabit, HABIT_UPDATE), HttpStatus.OK);
+		BaseResponse<HabitResponse> response = BaseResponse.of(updateHabit, HABIT_UPDATE);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@DeleteMapping("{habitId}")
-	ResponseEntity<BaseResponse<Void>> deleteHabit(@PathVariable Long habitId) {
+	public ResponseEntity<BaseResponse<Void>> deleteHabit(@PathVariable Long habitId) {
 		habitService.deleteHabit(habitId);
-		return new ResponseEntity<>(BaseResponse.of(null, HABIT_DELETE), HttpStatus.NO_CONTENT);
+		BaseResponse<Void> response = BaseResponse.of(null, HABIT_DELETE);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
 	}
 
 	@PostMapping("{habitId}/check")
-	ResponseEntity<BaseResponse<Void>> HabitCheck(@PathVariable Long habitId) {
+	public ResponseEntity<BaseResponse<Void>> HabitCheck(@PathVariable Long habitId) {
 		habitService.habitCheck(habitId);
-		return new ResponseEntity<>(BaseResponse.of(null, HABIT_CHECK_CREATE), HttpStatus.CREATED);
+		BaseResponse<Void> response = BaseResponse.of(null, HABIT_CHECK_CREATE);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
 	@DeleteMapping("{habitId}/check")
-	ResponseEntity<BaseResponse<Void>> HabitUnCheck(@PathVariable Long habitId) {
+	public ResponseEntity<BaseResponse<Void>> HabitUnCheck(@PathVariable Long habitId) {
 		habitService.habitUnCheck(habitId);
-		return new ResponseEntity<>(BaseResponse.of(null, HABIT_CHECK_DELETE), HttpStatus.NO_CONTENT);
+		BaseResponse<Void> response = BaseResponse.of(null, HABIT_CHECK_DELETE);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
 	}
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
@@ -1,5 +1,7 @@
 package com.clover.habbittracker.domain.habit.api;
 
+import static com.clover.habbittracker.global.dto.ResponseType.*;
+
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -19,6 +21,7 @@ import com.clover.habbittracker.domain.habit.dto.HabitRequest;
 import com.clover.habbittracker.domain.habit.dto.HabitResponse;
 import com.clover.habbittracker.domain.habit.dto.MyHabitResponse;
 import com.clover.habbittracker.domain.habit.service.HabitService;
+import com.clover.habbittracker.global.dto.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,40 +33,45 @@ public class HabitController {
 	private final HabitService habitService;
 
 	@GetMapping
-	ResponseEntity<List<MyHabitResponse>> getMyHabitList(Authentication authentication,@RequestParam(required = false) String date) {
-		Long memberId = (Long) authentication.getPrincipal();
-		return new ResponseEntity<>(habitService.getMyList(memberId,date),HttpStatus.OK);
+	ResponseEntity<BaseResponse<List<MyHabitResponse>>> getMyHabitList(Authentication authentication,
+		@RequestParam(required = false) String date) {
+		Long memberId = (Long)authentication.getPrincipal();
+		List<MyHabitResponse> data = habitService.getMyList(memberId, date);
+		return new ResponseEntity<>(BaseResponse.of(data, HABIT_READ), HttpStatus.OK);
 	}
 
 	@PostMapping
-	ResponseEntity<Long> createHabit(
+	ResponseEntity<BaseResponse<Long>> createHabit(
 		Authentication authentication,
 		@RequestBody HabitRequest request) {
 
 		Long memberId = (Long)authentication.getPrincipal();
-		return new ResponseEntity<>(habitService.register(memberId, request), HttpStatus.OK);
+		Long data = habitService.register(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(data, HABIT_CREATE), HttpStatus.CREATED);
 	}
 
 	@PutMapping("{habitId}")
-	ResponseEntity<HabitResponse> updateHabit(@PathVariable Long habitId,@RequestBody HabitRequest request) {
-		return new ResponseEntity<>(habitService.updateMyHabit(habitId,request),HttpStatus.OK);
+	ResponseEntity<BaseResponse<HabitResponse>> updateHabit(@PathVariable Long habitId,
+		@RequestBody HabitRequest request) {
+		HabitResponse data = habitService.updateMyHabit(habitId, request);
+		return new ResponseEntity<>(BaseResponse.of(data, HABIT_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("{habitId}")
-	ResponseEntity<Void> deleteHabit(@PathVariable Long habitId) {
+	ResponseEntity<BaseResponse<Void>> deleteHabit(@PathVariable Long habitId) {
 		habitService.deleteHabit(habitId);
-		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		return new ResponseEntity<>(BaseResponse.of(null, HABIT_DELETE), HttpStatus.NO_CONTENT);
 	}
 
 	@PostMapping("{habitId}/check")
-	ResponseEntity<Void> HabitCheck(@PathVariable Long habitId) {
+	ResponseEntity<BaseResponse<Void>> HabitCheck(@PathVariable Long habitId) {
 		habitService.habitCheck(habitId);
-		return new ResponseEntity<>(HttpStatus.OK);
+		return new ResponseEntity<>(BaseResponse.of(null, HABIT_CHECK_CREATE), HttpStatus.CREATED);
 	}
 
 	@DeleteMapping("{habitId}/check")
-	ResponseEntity<Void> HabitUnCheck(@PathVariable Long habitId) {
+	ResponseEntity<BaseResponse<Void>> HabitUnCheck(@PathVariable Long habitId) {
 		habitService.habitUnCheck(habitId);
-		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		return new ResponseEntity<>(BaseResponse.of(null, HABIT_CHECK_DELETE), HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/api/HabitController.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,28 +33,26 @@ public class HabitController {
 	private final HabitService habitService;
 
 	@GetMapping
-	ResponseEntity<BaseResponse<List<MyHabitResponse>>> getMyHabitList(Authentication authentication,
+	ResponseEntity<BaseResponse<List<MyHabitResponse>>> getMyHabitList(@AuthenticationPrincipal Long memberId,
 		@RequestParam(required = false) String date) {
-		Long memberId = (Long)authentication.getPrincipal();
-		List<MyHabitResponse> data = habitService.getMyList(memberId, date);
-		return new ResponseEntity<>(BaseResponse.of(data, HABIT_READ), HttpStatus.OK);
+		List<MyHabitResponse> myHabitList = habitService.getMyList(memberId, date);
+		return new ResponseEntity<>(BaseResponse.of(myHabitList, HABIT_READ), HttpStatus.OK);
 	}
 
 	@PostMapping
 	ResponseEntity<BaseResponse<Long>> createHabit(
-		Authentication authentication,
+		@AuthenticationPrincipal Long memberId,
 		@RequestBody HabitRequest request) {
 
-		Long memberId = (Long)authentication.getPrincipal();
-		Long data = habitService.register(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(data, HABIT_CREATE), HttpStatus.CREATED);
+		Long registerId = habitService.register(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(registerId, HABIT_CREATE), HttpStatus.CREATED);
 	}
 
 	@PutMapping("{habitId}")
 	ResponseEntity<BaseResponse<HabitResponse>> updateHabit(@PathVariable Long habitId,
 		@RequestBody HabitRequest request) {
-		HabitResponse data = habitService.updateMyHabit(habitId, request);
-		return new ResponseEntity<>(BaseResponse.of(data, HABIT_UPDATE), HttpStatus.OK);
+		HabitResponse updateHabit = habitService.updateMyHabit(habitId, request);
+		return new ResponseEntity<>(BaseResponse.of(updateHabit, HABIT_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("{habitId}")

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -1,5 +1,7 @@
 package com.clover.habbittracker.domain.member.api;
 
+import static com.clover.habbittracker.global.dto.ResponseType.*;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.service.MemberService;
+import com.clover.habbittracker.global.dto.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,20 +27,23 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@GetMapping("/me")
-	ResponseEntity<MemberResponse> getMyProfile(Authentication authentication) {
+	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(Authentication authentication) {
 		Long memberId = (Long)authentication.getPrincipal();
-		return new ResponseEntity<>(memberService.getProfile(memberId), HttpStatus.OK);
+		MemberResponse data = memberService.getProfile(memberId);
+		return new ResponseEntity<>(BaseResponse.of(data, MEMBER_READ), HttpStatus.OK);
 	}
 
 	@PutMapping("/me")
-	ResponseEntity<MemberResponse> updateMyProfile(Authentication authentication, @RequestBody MemberRequest request) {
+	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(Authentication authentication,
+		@RequestBody MemberRequest request) {
 		Long memberId = (Long)authentication.getPrincipal();
-		return new ResponseEntity<>(memberService.updateProfile(memberId, request), HttpStatus.OK);
+		MemberResponse data = memberService.updateProfile(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(data, MEMBER_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/me")
-	ResponseEntity<Void> deleteMember(Authentication authentication) {
-		memberService.deleteProfile((Long) authentication.getPrincipal());
-		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	ResponseEntity<BaseResponse<Void>> deleteMember(Authentication authentication) {
+		memberService.deleteProfile((Long)authentication.getPrincipal());
+		return new ResponseEntity<>(BaseResponse.of(null, MEMBER_DELETE), HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -29,19 +29,23 @@ public class MemberController {
 	@GetMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(@AuthenticationPrincipal Long memberId) {
 		MemberResponse profile = memberService.getProfile(memberId);
-		return new ResponseEntity<>(BaseResponse.of(profile, MEMBER_READ), HttpStatus.OK);
+		BaseResponse<MemberResponse> response = BaseResponse.of(profile, MEMBER_READ);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@PutMapping("/me")
 	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
-		@RequestBody MemberRequest request) {
+																 @RequestBody MemberRequest request) {
 		MemberResponse updateProfile = memberService.updateProfile(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(updateProfile, MEMBER_UPDATE), HttpStatus.OK);
+		BaseResponse<MemberResponse> response = BaseResponse.of(updateProfile, MEMBER_UPDATE);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@DeleteMapping("/me")
 	ResponseEntity<BaseResponse<Void>> deleteMember(@AuthenticationPrincipal Long memberId) {
 		memberService.deleteProfile(memberId);
-		return new ResponseEntity<>(BaseResponse.of(null, MEMBER_DELETE), HttpStatus.NO_CONTENT);
+		BaseResponse<Void> response = BaseResponse.of(null, MEMBER_DELETE);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
 	}
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -4,7 +4,7 @@ import static com.clover.habbittracker.global.dto.ResponseType.*;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -27,23 +27,21 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@GetMapping("/me")
-	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(Authentication authentication) {
-		Long memberId = (Long)authentication.getPrincipal();
-		MemberResponse data = memberService.getProfile(memberId);
-		return new ResponseEntity<>(BaseResponse.of(data, MEMBER_READ), HttpStatus.OK);
+	ResponseEntity<BaseResponse<MemberResponse>> getMyProfile(@AuthenticationPrincipal Long memberId) {
+		MemberResponse profile = memberService.getProfile(memberId);
+		return new ResponseEntity<>(BaseResponse.of(profile, MEMBER_READ), HttpStatus.OK);
 	}
 
 	@PutMapping("/me")
-	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(Authentication authentication,
+	ResponseEntity<BaseResponse<MemberResponse>> updateMyProfile(@AuthenticationPrincipal Long memberId,
 		@RequestBody MemberRequest request) {
-		Long memberId = (Long)authentication.getPrincipal();
-		MemberResponse data = memberService.updateProfile(memberId, request);
-		return new ResponseEntity<>(BaseResponse.of(data, MEMBER_UPDATE), HttpStatus.OK);
+		MemberResponse updateProfile = memberService.updateProfile(memberId, request);
+		return new ResponseEntity<>(BaseResponse.of(updateProfile, MEMBER_UPDATE), HttpStatus.OK);
 	}
 
 	@DeleteMapping("/me")
-	ResponseEntity<BaseResponse<Void>> deleteMember(Authentication authentication) {
-		memberService.deleteProfile((Long)authentication.getPrincipal());
+	ResponseEntity<BaseResponse<Void>> deleteMember(@AuthenticationPrincipal Long memberId) {
+		memberService.deleteProfile(memberId);
 		return new ResponseEntity<>(BaseResponse.of(null, MEMBER_DELETE), HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
@@ -1,0 +1,33 @@
+package com.clover.habbittracker.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BaseResponse<T> {
+
+	private final String code;
+	private final String message;
+	private final T data;
+
+	// public BaseResponse(T data, ResponseType responseType) {
+	// 	this.data = data;
+	// 	this.code = responseType.getCode();
+	// 	this.message = responseType.getMessage();
+	// }
+	//
+	// public BaseResponse(ResponseType responseType) {
+	// 	this.data = null;
+	// 	this.code = responseType.getCode();
+	// 	this.message = responseType.getMessage();
+	// }
+
+	public static <T> BaseResponse<T> of(T data,ResponseType responseType) {
+		return BaseResponse.<T>builder()
+			.data(data)
+			.code(responseType.name())
+			.message(responseType.getMessage())
+			.build();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
@@ -1,0 +1,26 @@
+package com.clover.habbittracker.global.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseType {
+	HABIT_CREATE("습관이 정상적으로 생성 되었습니다."),
+	HABIT_READ("습관 조회 요청이 성공 하였습니다."),
+	HABIT_UPDATE("습관 정보가 정상적으로 업데이트 되었습니다."),
+	HABIT_DELETE("습관이 정상적으로 삭제 되었습니다."),
+	HABIT_CHECK_CREATE("습관 체크가 정상적으로 생성 되었습니다."),
+	HABIT_CHECK_DELETE("습관 체크가 정상적으로 삭제 되었습니다."),
+	MEMBER_READ("회원 조회 요청이 성공하였습니다."),
+	MEMBER_UPDATE("회원 정보가 정상적으로 업데이트 되었습니다."),
+	MEMBER_DELETE("회원이 정상적으로 삭제 되었습니다."),
+	DIARY_CREATE("회고록이 정상적으로 생성 되었습니다."),
+	DIARY_READ("회고록 조회 요청이 성공하였습니다."),
+	DIARY_UPDATE("회고록 정보가 정상적으로 업데이트 되었습니다."),
+	DIARY_DELETE("회고록이 정상적으로 삭제 되었습니다.");
+
+	private final String message;
+
+	ResponseType(String message) {
+		this.message = message;
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -70,7 +70,7 @@ public class DiaryControllerTest {
 				.header("Authorization","Bearer " + accessJwt)
 				.contentType(APPLICATION_JSON)
 				.content(request))
-			.andExpect(status().isOk())
+			.andExpect(status().isCreated())
 			.andDo(print());
 	}
 
@@ -88,8 +88,8 @@ public class DiaryControllerTest {
 					.contentType(APPLICATION_JSON)
 					.content(request))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id", is(saveDiary.getId().intValue())))
-			.andExpect(jsonPath("$.content", is(diaryRequest.getContent())))
+			.andExpect(jsonPath("$.data.id", is(saveDiary.getId().intValue())))
+			.andExpect(jsonPath("$.data.content", is(diaryRequest.getContent())))
 			.andDo(print());
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -88,7 +88,7 @@ public class DiaryRepositoryTest {
 		for (int i = 0; i < 10; i++) {
 			diaryRepository.save(Diary.builder().content("테스트회고입니다." + i).member(testMember).build());
 		}
-		Map<String, LocalDateTime> dateTimeMap1 = DateCalculate.startEnd("2023-04");
+		Map<String, LocalDateTime> dateTimeMap1 = DateCalculate.startEnd(null);
 		Map<String, LocalDateTime> dateTimeMap2 = DateCalculate.startEnd("2023-03");
 
 		//when

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -63,7 +63,7 @@ public class HabitControllerTest {
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
-			.andExpect(status().isOk())
+			.andExpect(status().isCreated())
 			.andDo(print());
 	}
 
@@ -81,9 +81,9 @@ public class HabitControllerTest {
 					.contentType(APPLICATION_JSON)
 					.content(request))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").exists())
-			.andExpect(jsonPath("$.content").exists())
-			.andExpect(jsonPath("$.createDate").exists())
+			.andExpect(jsonPath("$.data.id").exists())
+			.andExpect(jsonPath("$.data.content").exists())
+			.andExpect(jsonPath("$.data.createDate").exists())
 			.andDo(print());
 	}
 
@@ -105,7 +105,7 @@ public class HabitControllerTest {
 		mockMvc.perform(
 				post("/habits/" + testHabit.getId() + "/check")
 					.header("Authorization", "Bearer " + accessJwt))
-			.andExpect(status().isOk())
+			.andExpect(status().isCreated())
 			.andDo(print());
 	}
 
@@ -129,10 +129,10 @@ public class HabitControllerTest {
 					.header("Authorization", "Bearer " + accessJwt)
 					.param("date", "2023-04"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.[0].id").exists())
-			.andExpect(jsonPath("$.[0].content").exists())
-			.andExpect(jsonPath("$.[0].createDate").exists())
-			.andExpect(jsonPath("$.[0].habitChecks").exists())
+			.andExpect(jsonPath("$.data.[0].id").exists())
+			.andExpect(jsonPath("$.data.[0].content").exists())
+			.andExpect(jsonPath("$.data.[0].createDate").exists())
+			.andExpect(jsonPath("$.data.[0].habitChecks").exists())
 			.andDo(print());
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -50,10 +50,10 @@ public class MemberControllerTest {
 		//when then
 		mockMvc.perform(get("/users/me").header("Authorization","Bearer " + accessJwt))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").exists())
-			.andExpect(jsonPath("$.email").exists())
-			.andExpect(jsonPath("$.nickName").exists())
-			.andExpect(jsonPath("$.profileImgUrl").exists())
+			.andExpect(jsonPath("$.data.id").exists())
+			.andExpect(jsonPath("$.data.email").exists())
+			.andExpect(jsonPath("$.data.nickName").exists())
+			.andExpect(jsonPath("$.data.profileImgUrl").exists())
 			.andDo(print());
 	}
 
@@ -73,8 +73,8 @@ public class MemberControllerTest {
 				.contentType(APPLICATION_JSON)
 				.content(request))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.nickName",is("updateNickName")))
-			.andExpect(jsonPath("$.profileImgUrl",is("updateProfileImgUrl")))
+			.andExpect(jsonPath("$.data.nickName",is("updateNickName")))
+			.andExpect(jsonPath("$.data.profileImgUrl",is("updateProfileImgUrl")))
 			.andDo(print());
 	}
 	@Test


### PR DESCRIPTION
### 작업 사항
[feat(dto) : BaseResponse 클래스 추가](https://github.com/potenday-project/Clover/pull/36/commits/93b67eee2e3174999392b2cf8d66384b6dc552e2)
- api 가 반환 하는 타입을 하나의 dto 클래스로 관리하기 위하여 추가하였습니다.
- 사용자의 요청에 대한 코드와 메세지, 데이터를 묶어서 전달합니다.
- 기존 Response 보다 디테일 한 정보를 담기 위해 추가하였습니다.

[feat(dto) : ResponseType enum 클래스 추가](https://github.com/potenday-project/Clover/pull/36/commits/512e55c940e3c54913cbd56115aa11adadadf600)
- 기존 ErrorType 과 같은 목적으로 생성하였습니다.
- 각자 연관되어 있는 상수를 표현하기 위해 enum 클래스로 생성하였습니다.

[chore(Controller) : Controller 반환 타입 변경](https://github.com/potenday-project/Clover/pull/36/commits/f43181105375b50df68345f93f8126c79f6b6f07)
- 모든 Controller 메소드가 BaseResponse 타입을 반환하도록 변경하였습니다.
- 기존에는 단순한 데이터만 전달 하였기에, ErrorResponse 와 마찬가지로 디테일 한 정보를 같이 보내고자 했습니다.
- 컨트롤러에서 반환하는 데이터를 데이터부분, 메세지, 코드 구조로 반환하도록 변경했습니다.

[test(Controller) : ControllerTest 검증 부분 수정](https://github.com/potenday-project/Clover/pull/36/commits/fcc9c8242cd77b6f82c9e173666a6b89525a78b2)
- 기존 Controller 반환 타입이 변경되었고, 반환되는 데이터만 검증하므로,jsonPath 를 $.data 로 변경하였습니다.